### PR TITLE
Adapt to new binary remote CLI

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [Unreleased]
+
+### Added
+- Support added for startup of binary remote agent ("Use Exec Server" option)
+
+
+## [0.0.1] - 2023-05-23
+
+### Added
+- Initial release

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support added for startup of binary remote agent ("Use Exec Server" option)
+- Multiple checks on remote stdin for --on-host directives from client
 
 
 ## [0.0.1] - 2023-05-23

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [1.0.0] - 2024-09-20
+
 ### Added
 - Support added for startup of binary remote agent ("Use Exec Server" option)
 - Multiple checks on remote stdin for --on-host directives from client

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Binding to `localhost` implies a TCP port is only reachable on the machine itsel
 
 With that change, the proxy worked perfectly.  Additional testing with user-forwarded ports in the VSCode application demonstrated that under this setup, there was no additional code necessary for that feature.
 
+### Changes for the Binary Exec Server
+
+The situation changed in early 2024 when Microsoft began deploying a binary remote agent ("exec server") in lieu of the node.js agent previously used.  The exec server defaults to binding to 127.0.0.1 and no equivalent to the traditional variant's `--host` flag was initially made available.  An [issue was filed](https://github.com/microsoft/vscode-remote-release/issues/9713) and Microsoft did eventually add an `--on-host` flag to the exec server, which allowed vscode-shell-proxy to be altered to fixup the startup command to bind to 0.0.0.0 instead.  As of 2024-04-10 this functionality was only available in the VSCode Insiders release stream, but eventually it should make it into the mainstream releases, too.
+
 ## Production setup
 
 The script requires Python 3.11, so a dedicated build of Python 3.11 was made from source and installed in `<install-prefix>/python-root`.  The proxy script was modified so that its hash-bang used `<install-prefix>/python-root/bin/python3` as its interpreter and the script was installed as `<install-prefix>/bin/vscode-shell-proxy.py`.

--- a/vscode-shell-proxy.py
+++ b/vscode-shell-proxy.py
@@ -1,4 +1,4 @@
-#!/opt/shared/slurm/add-ons/vscode-shell-proxy/python-root/bin/python3
+#!/usr/bin/env python3
 #
 # This script acts as a proxy for the Microsoft Visual Studio Code application's
 # Remote-SSH extension.  Remote-SSH must be setup to allow for remote command to
@@ -44,7 +44,8 @@ targetPortRegex = re.compile(r'^([^0-9]*listeningOn=[^0-9]*)(([0-9][0-9]*\.){3}[
 # Regex for input lines containing references to running servers bound to the
 # localhost interface only:
 localhostFixupNodeJSRegex = re.compile(r'((\$args =.*)|(\$VSCH_SERVER_SCRIPT.*))--host=127.0.0.1')
-localhostFixupCLIRegex = re.compile(r'(VSCODE_CLI_REQUIRE_TOKEN=[0-9a-fA-F-]*.*\$CLI_PATH.*command-shell )(.*)(--on-host=(([0-9][0-9]*\.){3}[0-9][0-9]*))?')
+localhostFixupCLIListenArgsRegex = re.compile(r'(LISTEN_ARGS=".*)(--on-host=(([0-9][0-9]*\.){3}[0-9][0-9]*))')
+localhostFixupCLICmdRegex = re.compile(r'(VSCODE_CLI_REQUIRE_TOKEN=[0-9a-fA-F-]*.*\$CLI_PATH.*command-shell )(.*)(--on-host=(([0-9][0-9]*\.){3}[0-9][0-9]*))')
 
 # Any commands this script itself sends to the remote shell should have their output
 # prefixed with this text to indicate they are NOT in response to VSCode application
@@ -136,7 +137,10 @@ def start_tcp_proxy(loop):
 
 def stdinProxyThread(drain, copyToFile=None):
     """Target function for a thread that will consume input from this script's stdin and write it to the remote shell's stdin.  Before any forwarding begins, introspective command(s) associated with this script are sent (and their output will be consumed by the stdout-forwarding thread).  When EOF is reached on this script's stdin the state is forwarded to END, yielding the shutdown of this script -- the connection from the VSCode application has been severed."""
-    global proxyStateCond, proxyState, localhostFixupNodeJSRegex, localhostFixupCLIRegex
+    global proxyStateCond, proxyState, localhostFixupNodeJSRegex, localhostFixupCLICmdRegex
+    global localhostFixupCLIListenArgsRegex
+
+    hasCLIListenArgs = False
     
     # Start by sending our special `hostname` command:
     hostnameCmd = 'echo "{:s}HOSTNAME=$(hostname)"\n'.format(ourShellOutputPrefix)
@@ -160,14 +164,23 @@ def stdinProxyThread(drain, copyToFile=None):
             else:
                 logging.debug('localhost line found and fixed: %s', inputLine.strip())
                 inputLine = inputLine.replace('127.0.0.1', '0.0.0.0')
-        elif '"$CLI_PATH" command-shell' in inputLine:
+        elif not hasCLIListenArgs and '"$CLI_PATH" command-shell' in inputLine:
             # Confirm it's one of the lines we're expecting:
-            localhostFixupMatch = localhostFixupCLIRegex.search(inputLine)
+            localhostFixupMatch = localhostFixupCLICmdRegex.search(inputLine)
             if localhostFixupMatch is None:
                 logging.warning('unanticipated localhost line found: %s', inputLine.strip())
             else:
                 logging.debug('localhost line found and fixed: %s', inputLine.strip())
-                inputLine = re.sub(localhostFixupCLIRegex, r'\g<1> --on-host=0.0.0.0 \g<2>', inputLine)
+                inputLine = re.sub(localhostFixupCLICmdRegex, r'\g<1> --on-host=0.0.0.0 \g<2>', inputLine)
+        elif 'LISTEN_ARGS=' in inputLine:
+            # Confirm it's the line we're expecting:
+            localhostFixupMatch = localhostFixupCLIListenArgsRegex.search(inputLine)
+            if ( localhostFixupMatch is None ):
+                logging.warning('unanticipated localhost line found: %s', inputLine.strip())
+            else:
+                logging.debug('localhost line found and fixed: %s', inputLine.strip())
+                inputLine = re.sub(localhostFixupCLIListenArgsRegex, r'\g<1> --on-host=0.0.0.0 ', inputLine)
+                hasCLIListenArgs = True
         
         if copyToFile is not None:
             copyToFile.write(inputLine); copyToFile.flush()

--- a/vscode-shell-proxy.py
+++ b/vscode-shell-proxy.py
@@ -39,11 +39,12 @@ targetPort = None
 
 # Regex for the line output by the vscode backend indicating the TCP port on which
 # it is listening:
-targetPortRegex = re.compile(r'^([^0-9]*listeningOn=[^0-9]*)([0-9][0-9]*)([^0-9]*)$')
+targetPortRegex = re.compile(r'^([^0-9]*listeningOn=[^0-9]*)(([0-9][0-9]*\.){3}[0-9][0-9]*:)?([0-9][0-9]*)([^0-9]*)$')
 
 # Regex for input lines containing references to running servers bound to the
 # localhost interface only:
-localhostFixupRegex = re.compile(r'((\$args =.*)|(\$VSCH_SERVER_SCRIPT.*))--host=127.0.0.1')
+localhostFixupNodeJSRegex = re.compile(r'((\$args =.*)|(\$VSCH_SERVER_SCRIPT.*))--host=127.0.0.1')
+localhostFixupCLIRegex = re.compile(r'(VSCODE_CLI_REQUIRE_TOKEN=[0-9a-fA-F-]*.*\$CLI_PATH.*command-shell )(.*)(--on-host=(([0-9][0-9]*\.){3}[0-9][0-9]*))?')
 
 # Any commands this script itself sends to the remote shell should have their output
 # prefixed with this text to indicate they are NOT in response to VSCode application
@@ -135,7 +136,7 @@ def start_tcp_proxy(loop):
 
 def stdinProxyThread(drain, copyToFile=None):
     """Target function for a thread that will consume input from this script's stdin and write it to the remote shell's stdin.  Before any forwarding begins, introspective command(s) associated with this script are sent (and their output will be consumed by the stdout-forwarding thread).  When EOF is reached on this script's stdin the state is forwarded to END, yielding the shutdown of this script -- the connection from the VSCode application has been severed."""
-    global proxyStateCond, proxyState, localhostFixupRegex
+    global proxyStateCond, proxyState, localhostFixupNodeJSRegex, localhostFixupCLIRegex
     
     # Start by sending our special `hostname` command:
     hostnameCmd = 'echo "{:s}HOSTNAME=$(hostname)"\n'.format(ourShellOutputPrefix)
@@ -153,12 +154,20 @@ def stdinProxyThread(drain, copyToFile=None):
         # Localhost fixups?
         if '--host=127.0.0.1' in inputLine:
             # Confirm it's one of the lines we're expecting:
-            localhostFixupMatch = localhostFixupRegex.search(inputLine)
+            localhostFixupMatch = localhostFixupNodeJSRegex.search(inputLine)
             if localhostFixupMatch is None:
                 logging.warning('unanticipated localhost line found: %s', inputLine.strip())
             else:
                 logging.debug('localhost line found and fixed: %s', inputLine.strip())
                 inputLine = inputLine.replace('127.0.0.1', '0.0.0.0')
+        elif '"$CLI_PATH" command-shell' in inputLine:
+            # Confirm it's one of the lines we're expecting:
+            localhostFixupMatch = localhostFixupCLIRegex.search(inputLine)
+            if localhostFixupMatch is None:
+                logging.warning('unanticipated localhost line found: %s', inputLine.strip())
+            else:
+                logging.debug('localhost line found and fixed: %s', inputLine.strip())
+                inputLine = re.sub(localhostFixupCLIRegex, r'\g<1> --on-host=0.0.0.0 \g<2>', inputLine)
         
         if copyToFile is not None:
             copyToFile.write(inputLine); copyToFile.flush()
@@ -193,6 +202,8 @@ def stdoutProxyThread(faucet, copyToFile=None):
     """Consume output to the remote shell's stdout and write it to this script's stdout.  This function is far more complex compared to the stderrProxyThread() function:  the stdout lines must be scanned for output associated with commands issued by this script (e.g. to get the remote hostname) and the remote TCP port on which the vscode backend is listening.  Once those data are known, this script's TCP proxy can be started.  When EOF is reached on the remote shell's stdout the state is forwarded to END, yielding the shutdown of this script -- the connection to the remote shell has been severed."""
     global targetHost, targetPort, targetPortRegex, proxyStateCond, proxyState
     
+    listenOnHadHost = False
+    
     while True:
         logging.debug('Waiting on remote stdout...')
         outputLine = faucet.readline()
@@ -219,7 +230,8 @@ def stdoutProxyThread(faucet, copyToFile=None):
                 logging.debug('Remote vscode TCP listener port found: %s', outputLine.strip())
                 targetPortMatch = targetPortRegex.search(outputLine)
                 if targetPortMatch is not None:
-                    targetPort = int(targetPortMatch.group(2))
+                    targetPort = int(targetPortMatch.group(4))
+                    listenOnHadHost = (len(targetPortMatch.group(2)) > 0)
                     logging.info('Remote TCP port found:  %d', targetPort)
                 
                 # Don't print the line now, stash it for output once the TCP proxy
@@ -240,7 +252,8 @@ def stdoutProxyThread(faucet, copyToFile=None):
                 proxyStateCond.wait_for(lambda:checkProxyState(ProxyStates.PROXY_STARTED))
     
             # Reformat the line with the local listening port:
-            targetPortLine = re.sub(targetPortRegex, r'\g<1>{:d}\g<3>'.format(proxyPort), targetPortLine)
+            targetHostStr = '127.0.0.1:' if listenOnHadHost else ''
+            targetPortLine = re.sub(targetPortRegex, r'\g<1>{:s}{:d}\g<5>'.format(targetHostStr, proxyPort), targetPortLine)
             logging.debug('Remote vscode TCP listener line rewritten: %s', targetPortLine.strip())
         
             if copyToFile:


### PR DESCRIPTION
Microsoft have deprecated the node.js code base that originally implemented the remote side of the connection, replacing it with a binary executable.  In the process, they altered the output produced as the CLI starts up.  This prompted changes to the proxy script to handle the altered startup process:

- intercept default `--on-host=127.0.0.1` option to the binary executable and substitute `--on-host=0.0.0.0` to enable connections proxied through the login nodes